### PR TITLE
Preserve unsigned parent IDs in count and document schema

### DIFF
--- a/src/interactions_count.rs
+++ b/src/interactions_count.rs
@@ -8,20 +8,20 @@ pub fn count(df: DataFrame) -> PyDataFrame {
     let parent_ids = df
         .column("parent_id")
         .expect("couldnt extract parent_id column")
-        .cast(&DataType::Int64)
-        .expect("Failed to cast parent_id into i64");
+        .cast(&DataType::UInt64)
+        .expect("Failed to cast parent_id into u64");
     let restriction_fragments = df
         .column("restriction_fragment")
         .expect("couldnt extract restriction_fragment column")
         .cast(&DataType::Int64)
         .expect("Failed to cast restriction_fragment into i64");
 
-    let parent_ids = parent_ids.i64().expect("parent_id should be i64");
+    let parent_ids = parent_ids.u64().expect("parent_id should be u64");
     let restriction_fragments = restriction_fragments
         .i64()
         .expect("restriction_fragment should be i64");
 
-    let mut fragments_by_parent: HashMap<i64, Vec<i64>> = HashMap::new();
+    let mut fragments_by_parent: HashMap<u64, Vec<i64>> = HashMap::new();
     for (parent_id, restriction_fragment) in parent_ids
         .into_iter()
         .zip(restriction_fragments.into_iter())

--- a/tests/test_count.py
+++ b/tests/test_count.py
@@ -23,6 +23,28 @@ def test_count(data_path):
     assert not counts.empty
 
 
+def test_count_interactions_schema_contract_uses_unsigned_parent_ids():
+    df = pl.DataFrame(
+        {
+            "parent_id": [1, 1],
+            "restriction_fragment": [169686, 169744],
+        },
+        schema={
+            "parent_id": pl.UInt64,
+            "restriction_fragment": pl.Int64,
+        },
+    )
+
+    counts = interactions.count_interactions(df)
+
+    assert df.schema["parent_id"] == pl.UInt64
+    assert counts.schema == {
+        "bin1_id": pl.Int64,
+        "bin2_id": pl.Int64,
+        "count": pl.Int32,
+    }
+
+
 def test_count_interactions_preserves_unsigned_parent_ids_above_i64():
     df = pl.DataFrame(
         {

--- a/tests/test_count.py
+++ b/tests/test_count.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
+import polars as pl
 import pytest
+from capcruncher_tools import interactions
 from capcruncher_tools.count import count_viewpoint_pixels
 
 
@@ -19,3 +21,22 @@ def test_count(data_path):
     assert viewpoint == "Slc25A37"
     assert {"bin1_id", "bin2_id", "count"} <= set(counts.columns)
     assert not counts.empty
+
+
+def test_count_interactions_preserves_unsigned_parent_ids_above_i64():
+    df = pl.DataFrame(
+        {
+            "parent_id": [7, 7, 2**63 + 5, 2**63 + 5],
+            "restriction_fragment": [169686, 169744, 169686, 169744],
+        },
+        schema={
+            "parent_id": pl.UInt64,
+            "restriction_fragment": pl.Int64,
+        },
+    )
+
+    counts = interactions.count_interactions(df).sort(["bin1_id", "bin2_id"])
+
+    assert counts.to_dicts() == [
+        {"bin1_id": 169686, "bin2_id": 169744, "count": 2},
+    ]


### PR DESCRIPTION
This pull request updates the handling of the `parent_id` column in interaction counting to use unsigned 64-bit integers (`UInt64`) instead of signed 64-bit integers (`Int64`). This ensures compatibility with parent IDs that exceed the maximum value of signed integers, and adds tests to verify this behavior.

**Schema and Data Type Updates:**

* Changed the casting and access of the `parent_id` column in `src/interactions_count.rs` to use `UInt64` instead of `Int64`, and updated all related data structures and logic accordingly.

**Testing Enhancements:**

* Added `test_count_interactions_schema_contract_uses_unsigned_parent_ids` to verify that the schema contract for `parent_id` uses `UInt64` and that the output schema is as expected.
* Added `test_count_interactions_preserves_unsigned_parent_ids_above_i64` to ensure that parent IDs larger than the maximum `Int64` value are correctly handled and preserved in the output.
* Added necessary imports in `tests/test_count.py` for `polars` and `interactions`.